### PR TITLE
Increase input width

### DIFF
--- a/desktop/js/widget.JeedomConnect.js
+++ b/desktop/js/widget.JeedomConnect.js
@@ -377,7 +377,7 @@ function refreshAddWidgets() {
         </label>
         <div class='col-xs-9'>
         <div class='input-group'>
-        <input style="width:340px;" class="roundedLeft" id="visibility-cond-input" value="" cmdtype="info" cmdsubtype="undefined" configtype="info" configsubtype="undefined" />
+        <input style="width:600px;" class="roundedLeft" id="visibility-cond-input" value="" cmdtype="info" cmdsubtype="undefined" configtype="info" configsubtype="undefined" />
         
         <a class='btn btn-default btn-sm cursor bt_selectTrigger' tooltip='Choisir une commande' onclick="selectCmd('widgetModal #visibility-cond', 'info', 'undefined', 'undefined', true);">
         <i class='fas fa-list-alt'></i></a>`;
@@ -399,7 +399,7 @@ function refreshAddWidgets() {
     //Room
     option = `<li><div class='form-group'>
         <label class='col-xs-3 ${type == 'room' ? 'required' : ''}'>Pièce</label>
-        <div class='col-xs-9'><div class='input-group'><select style="width:340px;" id="room-input" value=''>
+        <div class='col-xs-9'><div class='input-group'><select style="width:600px;" id="room-input" value=''>
         <option value="none">Sélection  d'une pièce</option>`;
     option += roomListOptions;
 
@@ -422,7 +422,7 @@ function refreshAddWidgets() {
             isDisabled = isJcExpert ? '' : 'disabled';
             curOption += `<table><tr class="cmd">
             <td>
-              <input class='input-sm form-control roundedLeft needRefresh' style="width:250px;" id="${option.id}-input" value='' cmdId='' cmdType='' cmdSubType='' ${isDisabled} configtype='${option.type}' configsubtype='${option.subtype}' configlink='${option.value}'>
+              <input class='input-sm form-control roundedLeft needRefresh' style="width:600px;" id="${option.id}-input" value='' cmdId='' cmdType='' cmdSubType='' ${isDisabled} configtype='${option.type}' configsubtype='${option.subtype}' configlink='${option.value}'>
               <td>
                  <a class='btn btn-default btn-sm cursor bt_selectTrigger' tooltip='Choisir une commande' onclick="selectCmd('${option.id}', '${option.type}', '${option.subtype}', '${option.value}');">
                     <i class='fas fa-list-alt'></i></a>
@@ -468,14 +468,14 @@ function refreshAddWidgets() {
             type = (option.subtype != undefined) ? option.subtype : 'text';
             if (option.subtype == "multiline") {
                 curOption += `<div class='input-group'>
-        <div style="display:flex"><textarea style="width:340px;" id="${option.id}-input" value=''></textarea>`;
+        <div style="display:flex"><textarea style="width:600px;" id="${option.id}-input" value=''></textarea>`;
             } else {
                 var min = (option.min || false) ? `min="${option.min}"` : '';
                 var max = (option.max || false) ? `max="${option.max}"` : '';
                 var defaultValue = (option.default || false) ? `default="${option.default}"` : '';
 
                 curOption += `<div class='input-group'>
-        <div style="display:flex"><input type="${type}" style="width:340px;" ${min} ${max} ${defaultValue} id="${option.id}-input" value='${option.default || ''}'>`;
+        <div style="display:flex"><input type="${type}" style="width:600px;" ${min} ${max} ${defaultValue} id="${option.id}-input" value='${option.default || ''}'>`;
             }
 
             if (option.id == 'name' || (option.useCmd != 'undefined' && option.useCmd)) {
@@ -484,7 +484,7 @@ function refreshAddWidgets() {
               <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" style="height" >
                 <i class="fas fa-plus-square"></i>
               </a>
-              <ul class="dropdown-menu infos-select" input="${option.id}-input">`;
+              <ul class="dropdown-menu infos-select" input="${option.id}-input" style="left: -600px !important;">`;
                 if (widget.variables) {
                     widget.variables.forEach(v => {
                         curOption += `<li info="${v.name}" onclick="infoSelected('#${v.name}#', this)"><a href="#">#${v.name}#</a></li>`;
@@ -503,7 +503,7 @@ function refreshAddWidgets() {
          </div></div></li>`;
         } else if (option.category == "stringList") {
             var classSub = (option.id == "subtitle") ? "subtitleSelected" : "";
-            curOption += '<div class="input-group"><select style="width:340px;" id="' + option.id + '-input" class="' + classSub + '">';
+            curOption += '<div class="input-group"><select style="width:600px;" id="' + option.id + '-input" class="' + classSub + '">';
             if (!required) {
                 curOption += `<option value="none">Aucun</option>`;
             }
@@ -513,13 +513,13 @@ function refreshAddWidgets() {
             if (option.id == "subtitle") {
                 curOption += `<option value="custom">Personnalisé</option></select>`;
                 curOption += `<div style="display:flex">
-  					<textarea style="width:340px; margin-top:5px; display:none;" id="subtitle-input-value" value='none'></textarea>`;
+  					<textarea style="width:600px; margin-top:5px; display:none;" id="subtitle-input-value" value='none'></textarea>`;
 
                 curOption += `
             <div class="dropdown" id="subtitle-select" style=" display:none;">
             <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" style="height" >
             <i class="fas fa-plus-square"></i> </a>
-            <ul class="dropdown-menu infos-select" input="subtitle-input-value">`;
+            <ul class="dropdown-menu infos-select" input="subtitle-input-value" style="left: -600px !important;">`;
                 if (widget.variables) {
                     widget.variables.forEach(v => {
                         curOption += `<li info="${v.name}" onclick="infoSelected('#${v.name}#', this)"><a href="#">#${v.name}#</a></li>`;
@@ -568,8 +568,8 @@ function refreshAddWidgets() {
               </i> Ajouter</a></span><div id="imgList-option"></div>`;
             curOption += `</div></div></li>`;
         } else if (option.category == "scenario") {
-            curOption += `<div class='input-group'><input class='input-sm form-control roundedLeft' id="${option.id}-input" value='' scId='' disabled>
-    <span class='input-group-btn'><a class='btn btn-default btn-sm cursor bt_selectTrigger selectScenario' tooltip='Choisir un scenario' data-id="${option.id}" data-related="${option.id}-input">
+            curOption += `<div class='input-group'><input class='input-sm form-control roundedLeft' id="${option.id}-input" value='' scId='' disabled style="width: 600px;">
+    <span class='input-group-btn' style="position: absolute;left: 600px;"><a class='btn btn-default btn-sm cursor bt_selectTrigger selectScenario' tooltip='Choisir un scenario' data-id="${option.id}" data-related="${option.id}-input">
     <i class='fas fa-list-alt'></i></a></span></div>
       <div id='optionScenario-${option.id}' style='display:none;'>
         <div class="input-group input-group-sm" style="width: 100%">
@@ -1019,12 +1019,12 @@ function refreshMoreInfos() {
         item.index = i;
         var unit = item.unit || '';
         div += `<div class='input-group moreInfosItem' style="border-width:1px; border-style:dotted;" id="moreInfo-${item.id}" data-id="${item.id}">
-          <input style="width:260px;" class='input-sm form-control roundedLeft' id="${item.id}-input" value='${item.id}' disabled>
-          <label style="position:absolute; margin-left:5px; width: 40px;"> Nom : </label>
-          <input style="width:80px;position:absolute; margin-left:45px;" id="${item.id}-name-input" title='${item.name}' value='${item.name}'>
-          <label style="position:absolute; margin-left:130px; width: 42px;"> Unité : </label>
-          <input style="width:80px;position:absolute; margin-left:175px;" id="${item.id}-unit-input" value='${unit}'>
-          <i class="mdi mdi-arrow-up-down-bold" title="Déplacer" style="color:rgb(80, 120, 170);font-size:24px;margin-left:265px;cursor:grab!important;" aria-hidden="true"></i>
+          <input style="width:600px;" class='input-sm form-control roundedLeft' id="${item.id}-input" value='${item.id}' disabled><br>
+          <label style="position:relative; margin-left:25px; width: 46px;"> Nom : </label>
+          <input style="width:450px;position:absolute; " id="${item.id}-name-input" title='${item.name}' value='${item.name}'><br>
+          <label style="position:relative; margin-left:25px; width: 42px;"> Unité : </label>
+          <input style="width:80px;position:absolute; " id="${item.id}-unit-input" value='${unit}'>
+          <i class="mdi mdi-arrow-up-down-bold" title="Déplacer" style="color:rgb(80, 120, 170);font-size:24px;margin-left:460px;cursor:grab!important;" aria-hidden="true"></i>
           <i class="mdi mdi-minus-circle" style="color:rgb(185, 58, 62);font-size:24px;position:absolute; margin-left:5px;" aria-hidden="true" onclick="deleteMoreInfo('${item.id}');"></i>
           </div>`;
     });
@@ -1240,7 +1240,7 @@ function getHtmlItem(type, option) {
         option.id = option.from + '-' + option.id;
         html = `
         <div class="input-group input-group-sm" style="width: 100%">
-              <input class='input-sm form-control roundedLeft needRefresh actionListAttr' style="width:250px;" id="${option.id}-input" data-l1key="options" data-l2key="name" value='' cmdId='' cmdType='action' cmdSubType='other' ${isDisabled} configtype='action' configsubtype='other' configlink='${option.value}'>
+              <input class='input-sm form-control roundedLeft needRefresh actionListAttr' style="width:600px;" id="${option.id}-input" data-l1key="options" data-l2key="name" value='' cmdId='' cmdType='action' cmdSubType='other' ${isDisabled} configtype='action' configsubtype='other' configlink='${option.value}'>
               <input class='input-sm form-control roundedLeft actionListAttr' id="${option.id}-id" value='' data-l1key="options" data-l2key="id" style="display:none">              
                <a class='btn btn-default btn-sm cursor bt_selectTrigger' tooltip='Choisir une commande' onclick="selectCmd('${option.id}', 'action', 'other', '');">
                     <i class='fas fa-list-alt'></i></a>  


### PR DESCRIPTION
In order to improve readability of the fields on widget page.

Currently, widget are displayed like this:
![Current](https://user-images.githubusercontent.com/36851093/212081697-c497e9fc-d641-4db3-9e5d-d96dd8627803.png)
But input are smaller than command names, so not easy to work on them.

So I increased most of inputs up to 600px to make it more readable. By doing that I change the left parameter of the drop-down menu, this way we are able to read complete command information.
I also changed a bit "other command" bloc to have on first row the command, then on next two row for other information:
![New](https://user-images.githubusercontent.com/36851093/212083804-4210f36b-f5fd-47ea-a3f1-9d5512a57e90.png)
