### PR TITLE
Fix PHP Warnings when creating and deleting a device (eqLogic)

### DIFF
--- a/core/class/JeedomConnect.class.php
+++ b/core/class/JeedomConnect.class.php
@@ -1070,7 +1070,7 @@ class JeedomConnect extends eqLogic {
 				$QR = imagecreatefrompng($filepath);
 
 				// START TO DRAW THE IMAGE ON THE QR CODE
-				$logopath = dirname(__FILE__) . '/../../data/img/JeedomConnect_icon2.png';
+				$logopath = __DIR__ . '/../../data/img/JeedomConnect_icon2.webp';
 				$logo = imagecreatefromstring(file_get_contents($logopath));
 				$QR_width = imagesx($QR);
 				$QR_height = imagesy($QR);
@@ -1429,10 +1429,10 @@ class JeedomConnect extends eqLogic {
 	}
 
 	public static function removeAllData($apiKey) {
-		unlink(self::$_qr_dir . $apiKey . '.png');
-		unlink(self::$_config_dir . $apiKey . ".json");
-		unlink(self::$_config_dir . $apiKey . ".json.generated");
-		unlink(self::$_notif_dir . $apiKey . ".json");
+		@unlink(self::$_qr_dir . $apiKey . '.png');
+		@unlink(self::$_config_dir . $apiKey . ".json");
+		@unlink(self::$_config_dir . $apiKey . ".json.generated");
+		@unlink(self::$_notif_dir . $apiKey . ".json");
 		JeedomConnectUtils::delTree(self::$_backup_dir . $apiKey);
 
 		$allKey = config::searchKey('customData::' . $apiKey, 'JeedomConnect');

--- a/core/class/JeedomConnectUtils.class.php
+++ b/core/class/JeedomConnectUtils.class.php
@@ -572,11 +572,12 @@ class JeedomConnectUtils {
      * @return void
      */
     public static function delTree($dir) {
-        $files = array_diff(scandir($dir), array('.', '..'));
-        foreach ($files as $file) {
-            (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : unlink("$dir/$file");
+        $files = @scandir($dir);
+        if ($files === false) return true;
+        foreach (array_diff($files, array('.', '..')) as $file) {
+            (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : @unlink("$dir/$file");
         }
-        return rmdir($dir);
+        return @rmdir($dir);
     }
 
 


### PR DESCRIPTION
Hi,

```
Jeedom Core : 4.3.17
Version JC : 1.8.0.1 stable
DNS Jeedom : non
Statut Démon : Stoppé - (NA)

Equipements :
  NSPanel : v1.8.0 stable sur android [os : 27] - PAL
  BadTel JC : v1.8.0 stable sur android [os : 33] (polling) - PA
  tmp : non enregistré - PA
```

I got the following warnings when creating a new device and deleting it:
```
ON CREATE:
[warn] [pid 9288] sapi_apache2.c(349): [client 192.168.11.51:62753] PHP Warning:  file_get_contents(/var/www/html/plugins/JeedomConnect/core/class/../../data/img/JeedomConnect_icon2.png): failed to open stream: No such file or directory in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1040
[warn] [pid 9288] sapi_apache2.c(349): [client 192.168.11.51:62753] PHP Warning:  imagecreatefromstring(): Empty string or invalid image in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1040
[warn] [pid 9288] sapi_apache2.c(349): [client 192.168.11.51:62753] PHP Warning:  imagesx() expects parameter 1 to be resource, bool given in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1044
[warn] [pid 9288] sapi_apache2.c(349): [client 192.168.11.51:62753] PHP Warning:  imagesy() expects parameter 1 to be resource, bool given in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1045
[warn] [pid 9288] sapi_apache2.c(349): [client 192.168.11.51:62753] PHP Warning:  Division by zero in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1050
[warn] [pid 9288] sapi_apache2.c(349): [client 192.168.11.51:62753] PHP Warning:  imagecopyresampled() expects parameter 2 to be resource, bool given in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1052

ON DELETE:
[warn] [pid 9265] sapi_apache2.c(349): [client 192.168.11.51:63618] PHP Warning:  unlink(/var/www/html/plugins/JeedomConnect/core/class/../../data/configs/d9c1acc29de430a3ae4926f5dc919f0c.json.generated): No such file or directory in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnect.class.php on line 1401
[warn] [pid 9265] sapi_apache2.c(349): [client 192.168.11.51:63618] PHP Warning:  scandir(/var/www/html/plugins/JeedomConnect/core/class/../../data/backups/d9c1acc29de430a3ae4926f5dc919f0c): failed to open dir: No such file or directory in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnectUtils.class.php on line 606
[warn] [pid 9265] sapi_apache2.c(349): [client 192.168.11.51:63618] PHP Warning:  scandir(): (errno 2): No such file or directory in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnectUtils.class.php on line 606
[warn] [pid 9265] sapi_apache2.c(349): [client 192.168.11.51:63618] PHP Warning:  array_diff(): Expected parameter 1 to be an array, bool given in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnectUtils.class.php on line 606
[warn] [pid 9265] sapi_apache2.c(349): [client 192.168.11.51:63618] PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnectUtils.class.php on line 607
[warn] [pid 9265] sapi_apache2.c(349): [client 192.168.11.51:63618] PHP Warning:  rmdir(/var/www/html/plugins/JeedomConnect/core/class/../../data/backups/d9c1acc29de430a3ae4926f5dc919f0c): No such file or directory in /var/www/html/plugins/JeedomConnect/core/class/JeedomConnectUtils.class.php on line 610
```

This PR aims to fix them (lines does not match dev branch as it was seen and tested on stable branch).
- change in `core/class/JeedomConnect.class.php` on line `1073` fix the QRcode logo on creation,
- the other changes fixes warnings on deletion.

Regards,
Bad

